### PR TITLE
fix:#1337 code cut off in firefox

### DIFF
--- a/site/layouts/cookbook.php
+++ b/site/layouts/cookbook.php
@@ -8,7 +8,7 @@
   <main id="main" class="main">
     <div class="container">
       <div class="with-sidebar">
-        <article class="mb-24">
+        <article class="mb-24 w-100%">
           <?php slot('hero') ?>
           <header class="mb-12">
             <h1 class="h1"><?php slot('h1') ?><?php endslot() ?></h1>


### PR DESCRIPTION
closes #1337 and #1593

Not sure which additional templates need this fix.